### PR TITLE
add Twitter button to footer

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -1,3 +1,5 @@
 <div class="footer">
-	<a href="{{ "./imprint.html" }}">Impressum (legal notice)</a> | <a href='{{ "/feed.xml" | prepend: site.baseurl }}'><img src='{{ "/assets/img/site/feed-icon.png" | prepend: site.baseurl }}' alt='Atom 1.0 Feed' style="height: 20px;"></a>
+	<a href="{{ "./imprint.html" }}">Impressum (legal notice)</a> | 
+	<a href='{{ "/feed.xml" | prepend: site.baseurl }}'><img src='{{ "/assets/img/site/feed-icon.png" | prepend: site.baseurl }}' alt='Atom 1.0 Feed' style="height: 20px;"></a> | 
+	<span style="position: relative; top: 6px;"><a href="https://twitter.com/RSE_de?ref_src=twsrc%5Etfw" class="twitter-follow-button" data-show-count="false" data-dnt="true" alt="Twitter account">Follow @RSE_de</a><script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script></span>
 </div>


### PR DESCRIPTION
Maybe I missed it, but I did not find any reference to the Twitter account on the webside, so I added a follow-button to the footer:

![image](https://user-images.githubusercontent.com/1325054/33662518-505a3bba-da8c-11e7-99f6-df32bdb007a1.png)

Twitters ["Do not track" is enabled](https://dev.twitter.com/web/follow-button/parameters), so the button does not message back to Twitter simply by being opened and is (at least) not used for personalized suggestions or adds.