### PR TITLE
Fix typo in Konrads image path

### DIFF
--- a/_includes/mapdata.js
+++ b/_includes/mapdata.js
@@ -168,7 +168,7 @@ var rseFeatures = [
         "type": "Feature",
         "properties": {
             "name": "Konrad Förstner",
-            "popupContent": "<img src='../assets/img/map/KonradFoerstner.jpg'><a href='https://konrad.foerstner.org/'>Konrad F&ouml;rstner</a>, Universtität W&uuml;rzburg<br><br><em>Open *</em>"
+            "popupContent": "<img src='../assets/img/map/KonradFoerstner.png'><a href='https://konrad.foerstner.org/'>Konrad F&ouml;rstner</a>, Universtität W&uuml;rzburg<br><br><em>Open *</em>"
         },
         "geometry": {
             "type": "Point",


### PR DESCRIPTION
The image on the map is not shown due to a typo `jpg` -> `png`