### PR TITLE
Titel "Prof." raus.

### DIFF
--- a/de/conf2019/contact.md
+++ b/de/conf2019/contact.md
@@ -1,4 +1,4 @@
---- 
+---
 layout: default
 title: Kontakt
 weight: 400
@@ -26,7 +26,7 @@ Bei speziellen Fragen kontaktiere die entsprechenden Personen aus dem Komitee.
 ## Programm
 
 * **Program Chairs**: [Stephan Druskat](mailto:stephan.druskat@hu-berlin.de) (HU Berlin), [Frank Löffler](mailto:frank.loeffler@uni-jena.de)
-* **Talks Chairs**: [Tobias Schlauch](mailto:tobias.schlauch@dlr.de) (DLR), [Prof. Wilhelm Hasselbring](mailto:hasselbring@email.uni-kiel.de) (Uni Kiel)
+* **Talks Chairs**: [Tobias Schlauch](mailto:tobias.schlauch@dlr.de) (DLR), [Wilhelm Hasselbring](mailto:hasselbring@email.uni-kiel.de) (Uni Kiel)
 * **Workshops Chair**: [Konrad Förstner](mailto:konrad@foerstner.org) (Uni Würzburg)
 * **Poster Chair**: [Bernadette Fritzsch](mailto:Bernadette.Fritzsch@awi.de) (AWI)
 * **Diversity Chair**: [Joachim Wuttke](mailto:j.wuttke@fz-juelich.de) (FZJ)

--- a/en/conf2019/contact.md
+++ b/en/conf2019/contact.md
@@ -1,4 +1,4 @@
---- 
+---
 layout: default
 title: Contact
 weight: 400
@@ -26,13 +26,13 @@ If you have a specific question, feel free to get in touch with the appropriate 
 ## Program
 
 * **Program Chairs**: [Stephan Druskat](mailto:stephan.druskat@hu-berlin.de) (HU Berlin), [Frank Löffler](mailto:frank.loeffler@uni-jena.de)
-* **Talks Chairs**: [Tobias Schlauch](mailto:tobias.schlauch@dlr.de) (DLR), [Prof. Wilhelm Hasselbring](mailto:hasselbring@email.uni-kiel.de) (Uni Kiel)
+* **Talks Chairs**: [Tobias Schlauch](mailto:tobias.schlauch@dlr.de) (DLR), [Wilhelm Hasselbring](mailto:hasselbring@email.uni-kiel.de) (Uni Kiel)
 * **Workshops Chair**: [Konrad Förstner](mailto:konrad@foerstner.org) (Uni Würzburg)
 * **Poster Chair**: [Bernadette Fritzsch](mailto:Bernadette.Fritzsch@awi.de) (AWI)
 * **Diversity Chair**: [Joachim Wuttke](mailto:j.wuttke@fz-juelich.de) (FZJ)
 * **International Chairs**: [Kaja Scheliga](mailto:kaja.scheliga@os.helmholtz.de) (HGF, Helmholtz Open Science Coordiantion Office), [Stephan Janosch](mailto:janosch@mpi-cbg.de) (MPI-CPG)
 * **Logistics Representatives**: [Martin Hammitzsch](mailto:martin.hammitzsch@gfz-potsdam.de) (GFZ), [Jan Dietrich](mailto:dietrich@pik-potsdam.de) (PIK), [Frederieke Miesner](mailto:frederieke.miesner@awi.de) (AWI)
- 
+
 
 
 ![awi logo]({{ "/assets/img/conf/awi_logo.svg" | prepend: site.baseurl }}){: width="75px"}


### PR DESCRIPTION
Entweder alle mit Titel, vom B.Sc. bis zum Dr. habil., oder - m.E. besser - alle ohne.