### PR TITLE
Add info about generic travel support

### DIFF
--- a/de/conf2019/travel-grants.md
+++ b/de/conf2019/travel-grants.md
@@ -8,6 +8,31 @@ parent: info
 
 # Reisestipendien
 
+## deRSE19 Reiseunterstützung
+
+Wir können Dich unterstützen wenn Du Schwierigkeiten hast, Deine Teilnahme an der Konferenz zu finanzieren.
+
+### Bewerbung
+
+Wenn Du Dich für eine Reiseunterstützung bewerben willst, sende eine E-Mail mit
+dem Betreff "deRSE19 travel support" an 
+[konferenz@de-rse.org](mailto:konferenz@de-rse.org).
+
+Die E-Mail sollte Folgendes beinhalten:
+
+- Deinen Namen und Deine Institutionszugehörigkeit
+- Was Du zur Konferenz beizutragen planst
+- Die Gründe für Deine Bewerbung
+- Wofür Du finanzielle Unterstützung benötigst (z.B. Anreise, Unterkunft, Registrierungsgebühr)
+- Ob/wieviel Du selbst finanziell zu Deinen Reisekosten beisteuern kannst
+- Die Summe die Du für Deine Teilnahme benötigst
+
+
+Bewerbungen werden intern begutachtet bevor eine Entscheidung über eine Unterstützungszusage getroffen wird. 
+Der Rechtsweg ist ausgeschlossen.
+
+---
+
 ## Stipendien für Beitragende aus dem Vereinigten Königreich (UKRSE-Stipendium)
 
 Wir vergeben 4 Reisestipendien zu je maximal £500,- für Beitragende aus dem Vereinigten Königreich.

--- a/en/conf2019/travel-grants.md
+++ b/en/conf2019/travel-grants.md
@@ -8,6 +8,30 @@ parent: info
 
 # Travel grants
 
+## deRSE19 travel support
+
+We are able to provide travel support for participants who have difficulties
+funding their travel to the conference.
+
+### Application
+
+If you would like to apply for travel support, please send an email with the
+subject line "deRSE19 travel support" to
+[konferenz@de-rse.org](mailto:konferenz@de-rse.org).
+
+The email should include:
+
+- Your name and affiliation
+- What you plan to contribute to the conference
+- The reasons for your application
+- What you need financial support for (e.g., transport, accommodation, registration fee)
+- If/how much you can contribute financially to your travel costs yourself
+- The amount you would need to fund your attendance
+
+Applications will be reviewed internally before a decision about funding is made (no recourse to legal action).
+
+---
+
 ## Travel grants for contributors from the UK (UKRSE Bursaries)
 
 We award 4 Travel Bursaries of max. £500 each to contributors from the UK.
@@ -21,8 +45,9 @@ The bursaries have been endowed by the [UK Research Software Engineers Associati
 To qualify for a UKRSE Bursary, you have to be based in the UK, and have an
 accepted contribution to deRSE19.
 
-To apply, please send a PDF with the subject "UKRSE Bursary" to 
-[konferenz@de-rse.org](mailto:konferenz@de-rse.org).
+To apply, please send a PDF to 
+[konferenz@de-rse.org](mailto:konferenz@de-rse.org)
+with the subject line "UKRSE Bursary".
 
 The PDF should include:
 - Your name, the name of the institution where you work/study, your position
@@ -40,7 +65,3 @@ available after the initial round of decisions, we will accept further
 applications.
 
 Awardees will be sent further details on acceptance.
-
-## Further travel grants
-
-We anticipate the installation of further travel grants, details to follow.

--- a/en/conf2019/travel-grants.md
+++ b/en/conf2019/travel-grants.md
@@ -65,3 +65,7 @@ available after the initial round of decisions, we will accept further
 applications.
 
 Awardees will be sent further details on acceptance.
+
+## Further travel grants
+
+We anticipate the installation of further travel grants, details to follow.


### PR DESCRIPTION
As discussed during the finance call on 21 Feb 19, we have some money for supporting those that cannot afford to travel to the conf. This PR adds info on how to apply for travel support.

Please review and rebase asap, i.e., before the call closes (28 Feb).