### PR TITLE
Redo navigation

### DIFF
--- a/_includes/navbar.html
+++ b/_includes/navbar.html
@@ -4,7 +4,8 @@
     {% for node in pg %}
         <!-- Neglect imprint.html and index.html in either language -->
         {% unless node.path contains "imprint" or node.path contains "index" %}
-            {% if node.dir == page.dir %}
+        <!-- Process page only if it's in the same dir as the current page -->
+        {% if node.dir == page.dir %}
                 <!-- Identify parents and children for dropdown -->
                 <li><a href='{{ node.url | prepend: site.baseurl | append: ".html" }}'>{{ node.title }}</a></li>
             {% endif %}

--- a/_includes/navbar.html
+++ b/_includes/navbar.html
@@ -1,0 +1,14 @@
+<ul class='nav navbar-nav'>
+    <!-- Get a list of pages sorted by the "weight" variable from the YAML header of each page file -->
+    {% assign pg = site.pages | sort: "weight" %}
+    {% for node in pg %}
+        <!-- Neglect imprint.html and index.html in either language -->
+        {% unless node.path contains "imprint" or node.path contains "index" %}
+            {% if node.dir == page.dir %}
+                <!-- Identify parents and children for dropdown -->
+                <li><a href='{{ node.url | prepend: site.baseurl | append: ".html" }}'>{{ node.title }}</a></li>
+            {% endif %}
+        {% endunless %}
+    {% endfor %}
+    <li class='navbar-conflink'><a href='{{ "conf2019/index.html" | prepend: site.baseurl }}'>deRSE19</a></li>
+</ul>

--- a/_includes/navbar_blog.html
+++ b/_includes/navbar_blog.html
@@ -1,0 +1,14 @@
+<ul class='nav navbar-nav'>
+    <!-- Get a list of pages sorted by the "weight" variable from the YAML header of each page file -->
+    {% assign pg = site.pages | sort: "weight" %}
+    {% for node in pg %}
+        <!-- Neglect imprint.html and index.html in either language -->
+        {% unless node.path contains "imprint" or node.path contains "index" %}
+            {% if node.dir == lang %}
+                <!-- Identify parents and children for dropdown -->
+                <li><a href='{{ node.url | prepend: site.baseurl | append: ".html" }}'>{{ node.title }}</a></li>
+            {% endif %}
+        {% endunless %}
+    {% endfor %}
+    <li class='navbar-conflink'><a href='{{ "conf2019/index.html" | prepend: lang | prepend: site.baseurl }}'>deRSE19</a></li>
+</ul>

--- a/_includes/navbar_conf.html
+++ b/_includes/navbar_conf.html
@@ -1,0 +1,29 @@
+<ul class='nav navbar-nav'>
+    <!-- Get a list of pages sorted by the "weight" variable from the YAML header of each page file -->
+    {% assign pg = site.pages | sort: "weight" %}
+    {% for node in pg %}
+        <!-- Neglect imprint.html and index.html in either language -->
+        {% unless node.path contains "imprint" or node.path contains "index" %}
+            {% if node.dir == page.dir %}
+                <!-- Identify parents and children for dropdown -->
+                {% if node.isparent == true %}
+                    {% capture parent_id %}{{ node.name | remove: ".md" }}{% endcapture %}
+                    <li class='navbar-conflink dropdown'>
+                        <a class="nav-link dropdown-toggle" href='{{ node.url | prepend: site.baseurl | append: ".html" }}'  id="navbarDropdown" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">{{ node.title }} &#x25BC;</a>
+                        <div class="dropdown-menu" aria-labelledby="navbarDropdown">
+                            {% for node in pg %}
+                                {% if node.dir == page.dir and node.parent == parent_id %}
+                                    <a class="dropdown-item" href="{{ node.url | prepend: site.baseurl | append: ".html" }}">{{ node.title }}</a>
+                                {% endif %}
+                            {% endfor %}
+                        </div>
+                    </li>
+                    {% capture parent_id %}"false"{% endcapture %}
+                {% elsif node.ischild != true %}
+                    <li class='navbar-conflink'><a href='{{ node.url | prepend: site.baseurl | append: ".html" }}'>{{ node.title }}</a></li>
+                {% endif %}
+            {% endif %}
+        {% endunless %}
+    {% endfor %}
+    <li><a href='{{ "/index.html" | prepend: page.dir | remove: "/conf2019/" }}'>de-RSE e.V.</a></li>
+</ul>

--- a/_includes/navbar_conf.html
+++ b/_includes/navbar_conf.html
@@ -4,6 +4,7 @@
     {% for node in pg %}
         <!-- Neglect imprint.html and index.html in either language -->
         {% unless node.path contains "imprint" or node.path contains "index" %}
+            <!-- Process page only if it's in the same dir as the current page -->
             {% if node.dir == page.dir %}
                 <!-- Identify parents and children for dropdown -->
                 {% if node.isparent == true %}

--- a/_includes/navbar_post.html
+++ b/_includes/navbar_post.html
@@ -1,0 +1,18 @@
+<ul class='nav navbar-nav'>
+    <!-- Get a list of pages sorted by the "weight" variable from the YAML header of each page file -->
+    {% assign pg = site.pages | sort: "weight" %}
+    {% for node in pg %}
+        <!-- Neglect imprint.html and index.html in either language -->
+        {% unless node.path contains "imprint" or node.path contains "index" %}
+            <!-- Neglect conf links in either language -->
+            {% unless node.dir contains "conf2019" %}
+                <!-- Process page only if it's on the same path as the current page regarding language -->
+                {% if node.dir contains lang %}
+                    <!-- node.url does not contain file endings and is relative: make absolute and append file ending -->
+                    <li><a href='{{ node.url | prepend: site.baseurl | append: ".html" }}'>{{ node.title }}</a></li>
+                {% endif %}
+            {% endunless %}
+        {% endunless %}
+    {% endfor %}
+    <li class='navbar-conflink'><a href='{{ "conf2019/index.html" | prepend: site.baseurl }}'>deRSE19</a></li>
+</ul>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -16,63 +16,40 @@
             </div>
             <div id='navbar' class='collapse navbar-collapse'>
                 <ul class='nav navbar-nav'>
-                    <!-- Set variable "lang" to reflect page language -->
-                    {% if page.url contains "/en/" %}
-                        {% assign lang = "/en/" %}
-                        {% assign conf2019_title = "deRSE19 Conference" %}
-                    {% elsif page.url contains "/de/" %}
-                        {% assign lang ="/de/" %}
-                        {% assign conf2019_title = "deRSE19 Konferenz" %}
+		    {% if page.dir contains "/conf2019/" %}
+                        <li class='navbar-conflink'><a href='{{ "index.html" | prepend: site.baseurl }}'>deRSE19</a></li>
                     {% endif %}
-                    <!-- Set variable "page_conf2019" to reflect if we are on a conference page -->
-                    {% assign page_conf2019 = false %}
-                    {% assign conf2019_link = "conf2019/index.html" %}
-                    {% if page.url contains "/conf2019/" %}
-                        {% assign page_conf2019 = true %}
-                        {% assign conf2019_link = "index.html" %}
-                        <li class='navbar-conflink'><a href='{{ conf2019_link | prepend: site.baseurl }}'>{{ conf2019_title }}</a></li>
-                    {% endif %}
-                    <!-- Get a list of pages sorted by the "weight" variable from the YAML header of each page file -->
+
+		    <!-- Get a list of pages sorted by the "weight" variable from the YAML header of each page file -->
                     {% assign pg = site.pages | sort: "weight" %}
                     {% for node in pg %}
                         <!-- Neglect imprint.html and index.html in either language -->
                         {% unless node.path contains "imprint" or node.path contains "index" %}
-                            <!-- Set variable "node_conf2019" if node links to a conference page -->
-                            {% assign node_conf2019 = false %}
-                            {% if node.url contains "/conf2019/" %}
-                                {% assign node_conf2019 = true %}
-                            {% endif %}
-                            <!-- Process page only if it's on the same path as the current page regarding language and conference -->
-                            {% if node.url contains lang and node_conf2019 == page_conf2019 %}
-                                <!-- node.url does not contain file endings and is relative: make absolute and append file ending -->
-                                {% if node_conf2019 %}
-                                    <!-- Identify parents and children for dropdown -->
-                                    {% if node.isparent == true %}
-                                        {% capture parent_id %}{{ node.name | remove: ".md" }}{% endcapture %}
-                                        <li class='navbar-conflink dropdown'>
-                                            <a class="nav-link dropdown-toggle" href='{{ node.url | prepend: site.baseurl | append: ".html" }}'  id="navbarDropdown" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">{{ node.title }} &#x25BC;</a>
-                                            <div class="dropdown-menu" aria-labelledby="navbarDropdown">
-                                                {% for node in pg %}
-                                                    {% if node.parent == parent_id and node.url contains lang%}
-                                                        <a class="dropdown-item" href="{{ node.url | prepend: site.baseurl | append: ".html" }}">{{ node.title }}</a>
-                                                    {% endif %}
-                                                {% endfor %}
-                                            </div>
-                                        </li>
-                                        {% capture parent_id %}"false"{% endcapture %}
-                                    {% elsif node.ischild != true %}
-                                            <li class='navbar-conflink'><a href='{{ node.url | prepend: site.baseurl | append: ".html" }}'>{{ node.title }}</a></li>
-                                    {% endif %}
-                                {% else %}
-                                    <li><a href='{{ node.url | prepend: site.baseurl | append: ".html" }}'>{{ node.title }}</a></li>
+			    {% if node.dir == page.dir %}
+                                <!-- Identify parents and children for dropdown -->
+                                {% if node.isparent == true %}
+                                     {% capture parent_id %}{{ node.name | remove: ".md" }}{% endcapture %}
+                                     <li class='navbar-conflink dropdown'>
+                                        <a class="nav-link dropdown-toggle" href='{{ node.url | prepend: site.baseurl | append: ".html" }}'  id="navbarDropdown" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">{{ node.title }} &#x25BC;</a>
+                                        <div class="dropdown-menu" aria-labelledby="navbarDropdown">
+                                            {% for node in pg %}
+                                                {% if node.parent == parent_id and node.url contains lang%}
+                                                    <a class="dropdown-item" href="{{ node.url | prepend: site.baseurl | append: ".html" }}">{{ node.title }}</a>
+                                                {% endif %}
+                                            {% endfor %}
+                                        </div>
+                                    </li>
+                                    {% capture parent_id %}"false"{% endcapture %}
+                                {% elsif node.ischild != true %}
+                                    <li class='navbar-conflink'><a href='{{ node.url | prepend: site.baseurl | append: ".html" }}'>{{ node.title }}</a></li>
                                 {% endif %}
                             {% endif %}
                         {% endunless %}
                     {% endfor %}
-                    {% unless page_conf2019 %}
-                        <li class='navbar-conflink'><a href='{{ conf2019_link | prepend: site.baseurl }}'>{{ conf2019_title }}</a></li>
+		    {% unless page.dir contains "/conf2019/" %}
+                        <li class='navbar-conflink'><a href='{{ "conf2019/index.html" | prepend: site.baseurl }}'>deRSE19</a></li>
                     {% endunless %}
-                </ul>
+		</ul>
                 <ul class='nav navbar-nav pull-right'>
                     <!-- Build language-relative URL from current URL -->
                     {% assign en-url = page.url | replace: "/de/", "/en/" %}

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -11,64 +11,34 @@
                     <span class='icon-bar'></span>
                     <span class='icon-bar'></span>
                 </button>
-                <a class='navbar-brand navbar-logo' href='/index.html'><img src='{{ site.baseurl | append: "/assets/img/site/rse.png" }}'/></a>
+                <a class='navbar-brand navbar-logo' href='{{ "index.html" | prepend: site.baseurl }}'><img src='{{ site.baseurl | append: "/assets/img/site/rse.png" }}'/></a>
                 <!-- a class='navbar-brand' href='/index.html'>de-RSE</a -->
             </div>
             <div id='navbar' class='collapse navbar-collapse'>
-                <ul class='nav navbar-nav'>
-		    {% if page.dir contains "/conf2019/" %}
-                        <li class='navbar-conflink'><a href='{{ "index.html" | prepend: site.baseurl }}'>deRSE19</a></li>
-                    {% endif %}
-
-		    <!-- Get a list of pages sorted by the "weight" variable from the YAML header of each page file -->
-                    {% assign pg = site.pages | sort: "weight" %}
-                    {% for node in pg %}
-                        <!-- Neglect imprint.html and index.html in either language -->
-                        {% unless node.path contains "imprint" or node.path contains "index" %}
-			    {% if node.dir == page.dir %}
-                                <!-- Identify parents and children for dropdown -->
-                                {% if node.isparent == true %}
-                                     {% capture parent_id %}{{ node.name | remove: ".md" }}{% endcapture %}
-                                     <li class='navbar-conflink dropdown'>
-                                        <a class="nav-link dropdown-toggle" href='{{ node.url | prepend: site.baseurl | append: ".html" }}'  id="navbarDropdown" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">{{ node.title }} &#x25BC;</a>
-                                        <div class="dropdown-menu" aria-labelledby="navbarDropdown">
-                                            {% for node in pg %}
-                                                {% if node.parent == parent_id and node.url contains lang%}
-                                                    <a class="dropdown-item" href="{{ node.url | prepend: site.baseurl | append: ".html" }}">{{ node.title }}</a>
-                                                {% endif %}
-                                            {% endfor %}
-                                        </div>
-                                    </li>
-                                    {% capture parent_id %}"false"{% endcapture %}
-                                {% elsif node.ischild != true %}
-                                    <li class='navbar-conflink'><a href='{{ node.url | prepend: site.baseurl | append: ".html" }}'>{{ node.title }}</a></li>
-                                {% endif %}
-                            {% endif %}
-                        {% endunless %}
-                    {% endfor %}
-		    {% unless page.dir contains "/conf2019/" %}
-                        <li class='navbar-conflink'><a href='{{ "conf2019/index.html" | prepend: site.baseurl }}'>deRSE19</a></li>
-                    {% endunless %}
-		</ul>
+                {% if page.dir contains "/conf2019/" %}
+                    {% include navbar_conf.html %}
+                {% else %}
+                    {% include navbar.html %}
+                {% endif %}
                 <ul class='nav navbar-nav pull-right'>
                     <!-- Build language-relative URL from current URL -->
                     {% assign en-url = page.url | replace: "/de/", "/en/" %}
                     {% assign de-url = page.url | replace: "/en/", "/de/" %}
                     <!-- Ignore index pages, as their URL will always be '/{language}/', not a specific site -->
                     {% unless page.path contains "index" %}
-                    {% assign en-url = en-url | append: ".html" %}
-                    {% assign de-url = de-url | append: ".html" %}
+                        {% assign en-url = en-url | append: ".html" %}
+                        {% assign de-url = de-url | append: ".html" %}
                     {% endunless %}
                     {% if page.path contains "404" %}
-                    {% assign en-url = "/en/" %}
-                    {% assign de-url = "/de/" %}
+                        {% assign en-url = "/en/" %}
+                        {% assign de-url = "/de/" %}
                     {% endif %}
                     <li><a href='{{ de-url | prepend: site.baseurl }}'>Deutsch</a></li>
                     <li><a href='{{ en-url | prepend: site.baseurl }}'>English</a></li>
                 </ul>
-            </div>
-            <!--/.nav-collapse -->
         </div>
+        <!--/.nav-collapse -->
+    </div>
     </nav>
     <div class="container">
         <div class="starter-template">

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -1,48 +1,62 @@
 <!DOCTYPE html>
 <html lang="en">
-    
-  {% include head.html %}
-  
-  <body class="home">
+{% include head.html %}
 
+<body class="home">
     <nav class='navbar navbar-default navbar-fixed-top' data-nav-highlight='true'>
-      <div class='container container-navbar'>
-        <div class='navbar-header'>
-          <button type='button' class='navbar-toggle collapsed' data-toggle='collapse' data-target='#navbar' aria-expanded='false' aria-controls='navbar'>
-            <span class='icon-bar'></span>
-            <span class='icon-bar'></span>
-            <span class='icon-bar'></span>
-          </button>
-          <!-- Set variable "lang" to reflect post's menu language -->
-          {% if page.menulang == "en" %}
-            {% assign lang = "/en/" %}
-          {% elsif page.menulang == "de" %}
-            {% assign lang ="/de/" %}
-          {% endif %}
-          <!-- Get a list of pages sorted by the "weight" variable from the YAML header of each page file -->
-          <a class='navbar-brand navbar-logo' href='{{ lang | prepend: site.baseurl | append: "index.html" }}'><img src='{{ site.baseurl | append: "/assets/img/site/rse.png" }}'/></a>
+        <div class='container container-navbar'>
+            <div class='navbar-header'>
+                <button type='button' class='navbar-toggle collapsed' data-toggle='collapse' data-target='#navbar' aria-expanded='false' aria-controls='navbar'>
+                  <span class='icon-bar'></span>
+                  <span class='icon-bar'></span>
+                  <span class='icon-bar'></span>
+                </button>
+                <!-- Set variable "lang" to reflect post's menu language -->
+                {% if page.menulang == "en" %}
+                    {% assign lang = "/en/" %}
+                {% elsif page.menulang == "de" %}
+                    {% assign lang ="/de/" %}
+                {% endif %}
+                {% assign indexurl = lang | prepend: site.baseurl | append: "index.html" %}
+                {% assign page_conf2019 = false %}
+                {% assign conf2019_link = "conf2019/index.html" %}
+                <!-- Get a list of pages sorted by the "weight" variable from the YAML header of each page file -->
+                <a class='navbar-brand navbar-logo' href='{{ indexurl }}'><img src='{{ site.baseurl | append: "/assets/img/site/rse.png" }}'/></a>
+                <!-- <a class='navbar-brand' href='{{ indexurl }}'>de-RSE</a> -->
+            </div>
+            <div id='navbar' class='collapse navbar-collapse'>
+                {% include navbar_blog.html %}
+                <ul class='nav navbar-nav pull-right'>
+                    <!-- Build language-relative URL from current URL -->
+                    {% assign en-url = page.url | replace: "/de/", "/en/" %}
+                    {% assign de-url = page.url | replace: "/en/", "/de/" %}
+                    <!-- Ignore index pages, as their URL will always be '/{language}/', not a specific site -->
+                    {% unless page.path contains "index" %}
+                        {% assign en-url = en-url | append: ".html" %}
+                        {% assign de-url = de-url | append: ".html" %}
+                    {% endunless %}
+                    {% if page.path contains "404" %}
+                        {% assign en-url = "/en/" %}
+                        {% assign de-url = "/de/" %}
+                    {% endif %}
+                    <!-- Language menu items take the user back to the blog main page -->
+                    <li><a href='{{ "/de/blog.html" | prepend: site.baseurl }}'>Deutsch</a></li>
+                    <li><a href='{{ "/en/blog.html" | prepend: site.baseurl }}'>English</a></li>
+                </  ul>
+            </div><!--/.nav-collapse -->
         </div>
-        <div id='navbar' class='collapse navbar-collapse'>
-          {% include navbar_post.html %}          
-          <ul class='nav navbar-nav pull-right'>
-            <!-- Language menu items take the user back to the blog main page -->
-            <li><a href='{{ "/de/blog.html" | prepend: site.baseurl }}'>Deutsch</a></li>
-            <li><a href='{{ "/en/blog.html" | prepend: site.baseurl }}'>English</a></li>
-          </ul>
-        </div><!--/.nav-collapse -->
-      </div>
     </nav>
 
     <div class="container">
-      <div class="starter-template">
-        <h1>{{ page.title }}</h1>
-          <p>{{ page.author }}, {{ page.date | date: "%B %-d, %Y" }}</p>
-        <hr>
-        {{ content }}
-        <br/>
-      </div>
+        <div class="starter-template">
+            <h1>{{ page.title }}</h1>
+                <p>{{ page.author }}, {{ page.date | date: "%B %-d, %Y" }}</p>
+            <hr>
+            {{ content }}
+            <br/>
+        </div>
     </div>
     {% include footer.html %}
-  </body>
-</html>
+</body>
 
+</html>

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -16,67 +16,14 @@
           <!-- Set variable "lang" to reflect post's menu language -->
           {% if page.menulang == "en" %}
             {% assign lang = "/en/" %}
-            {% assign conf2019_title = "deRSE19 Conference" %}
           {% elsif page.menulang == "de" %}
             {% assign lang ="/de/" %}
-            {% assign conf2019_title = "deRSE19 Konferenz" %}
-          {% endif %}
-          {% assign indexurl = lang | prepend: site.baseurl | append: "index.html" %}
-          {% assign page_conf2019 = false %}
-          {% assign conf2019_link = "conf2019/index.html" %}
-          {% if page.url contains "/conf2019/" %}
-              {% assign page_conf2019 = true %}
-              {% assign conf2019_link = "index.html" %}
-              <li class='navbar-conflink'><a href='{{ conf2019_link | prepend: site.baseurl }}'>{{ conf2019_title }}</a></li>
           {% endif %}
           <!-- Get a list of pages sorted by the "weight" variable from the YAML header of each page file -->
-          <a class='navbar-brand navbar-logo' href='{{ indexurl }}'><img src='{{ site.baseurl | append: "/assets/img/site/rse.png" }}'/></a>
-          <a class='navbar-brand' href='{{ indexurl }}'>de-RSE</a>
+          <a class='navbar-brand navbar-logo' href='{{ lang | prepend: site.baseurl | append: "index.html" }}'><img src='{{ site.baseurl | append: "/assets/img/site/rse.png" }}'/></a>
         </div>
         <div id='navbar' class='collapse navbar-collapse'>
-          <ul class='nav navbar-nav'>
-          <!-- Get a list of pages sorted by the "weight" variable from the YAML header of each page file -->
-          {% assign pg = site.pages | sort: "weight" %}
-          {% for node in pg %}
-              <!-- Neglect imprint.html and index.html in either language -->
-              {% unless node.path contains "imprint" or node.path contains "index" %}
-                  <!-- Set variable "node_conf2019" if node links to a conference page -->
-                  {% assign node_conf2019 = false %}
-                  {% if node.url contains "/conf2019/" %}
-                      {% assign node_conf2019 = true %}
-                  {% endif %}
-                  <!-- Process page only if it's on the same path as the current page regarding language and conference -->
-                  {% if node.url contains lang and node_conf2019 == page_conf2019 %}
-                      <!-- node.url does not contain file endings and is relative: make absolute and append file ending -->
-                      {% if node_conf2019 %}
-                          <!-- Identify parents and children for dropdown -->
-                          {% if node.isparent == true %}
-                              {% capture parent_id %}{{ node.name | remove: ".md" }}{% endcapture %}
-                              <li class='navbar-conflink dropdown'>
-                                  <a class="nav-link dropdown-toggle" href='{{ node.url | prepend: site.baseurl | append: ".html" }}'  id="navbarDropdown" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">{{ node.title }} &#x25BC;</a>
-                                  <div class="dropdown-menu" aria-labelledby="navbarDropdown">
-                                      {% for node in pg %}
-                                          {% if node.parent == parent_id and node.url contains lang%}
-                                              <a class="dropdown-item" href="{{ node.url | prepend: site.baseurl | append: ".html" }}">{{ node.title }}</a>
-                                          {% endif %}
-                                      {% endfor %}
-                                  </div>
-                              </li>
-                              {% capture parent_id %}"false"{% endcapture %}
-                          {% elsif node.ischild != true %}
-                                  <li class='navbar-conflink'><a href='{{ node.url | prepend: site.baseurl | append: ".html" }}'>{{ node.title }}</a></li>
-                          {% endif %}
-                      {% else %}
-                          <li><a href='{{ node.url | prepend: site.baseurl | append: ".html" }}'>{{ node.title }}</a></li>
-                      {% endif %}
-                  {% endif %}
-              {% endunless %}
-          {% endfor %}
-          {% unless page_conf2019 %}
-              <li class='navbar-conflink'><a href='{{ conf2019_link | prepend: site.baseurl }}'>{{ conf2019_title }}</a></li>
-          {% endunless %}
-
-          </ul>
+          {% include navbar_post.html %}          
           <ul class='nav navbar-nav pull-right'>
             <!-- Language menu items take the user back to the blog main page -->
             <li><a href='{{ "/de/blog.html" | prepend: site.baseurl }}'>Deutsch</a></li>


### PR DESCRIPTION
Überarbeitung der Navigation:
* Nodes werden nun über das DIR in dem die Dateien liegen erkannt. Bisher wurde für die Seite sowie die Nodes die Sprache und ob es sich um eine Konferenzseite aus der URL extrahiert und diese dann verglichen.
* Die eigentliche Navigation wurde in zwei separate Dateien ausgelagert. Eine für die Hauptseite, eine für die Konferenzseite. Dies vermindert die Fallunterscheidungen, welche nötig sind um die unterschiedlichen Farbschemas und Links zu ermöglichen,
* Die Entscheidung welche Navigation genutzt wird erfolgt in der default.html. Diese einmalige Fallunterscheidung erlaubt uns das Nutzen eines Vorlage.

Weiterhin zeigt das Logo nun immer auf die lokale Index-Datei. Dies bedeutet keine Sprachsprünge mehr sowie das man im Konferenzbereich auf die dortige Startseite kommt. Um von der Konfernz wieder auf die Hauptseite zu kommen gibt es stattdessen jetzt rechts einen Link auf den Verein. Somit ist der Aufbau auf beiden Teilseiten gleich (Logo zeigt auf Index, rechts Link zum anderen Bereich).