### PR TITLE
Fix missing viewport meta

### DIFF
--- a/_includes/head_default.html
+++ b/_includes/head_default.html
@@ -27,7 +27,7 @@
   <link rel="alternate" type="application/rss+xml" title="{{ site.title }}" href="{{ "/feed.xml" | prepend: site.baseurl | prepend: site.url }}" />
 
   <meta name="description" content="">
-  <meta name="" content="">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
   
   <link rel="icon" href="{{ "/assets/img/site/favicon.ico" | prepend: site.baseurl }}">
   <link rel="canonical" href="{{ page.url | replace:'index.html','' | prepend: site.baseurl | prepend: site.url }}">


### PR DESCRIPTION
This PR fixes the responsiveness of the page when used on mobile devices.
The viewport meta tag was missing in the head.