### PR TITLE
Split positions page into list and process page

### DIFF
--- a/_includes/navbar.html
+++ b/_includes/navbar.html
@@ -31,7 +31,7 @@
                 {% assign pg = site.pages | sort: "weight" %}
                 {% for node in pg %}
                     <!-- Neglect imprint.html and index.html in either language -->
-                    {% unless node.path contains "imprint" or node.path contains "index" %}
+                    {% unless node.exclude %}
                         <!-- Set variable "node_conf2019" if node links to a conference page -->
                         {% assign node_conf2019 = false %}
                         {% if node.url contains "/conf2019/" %}

--- a/de/imprint.md
+++ b/de/imprint.md
@@ -1,6 +1,7 @@
 ---
 layout: default
 title: Research Software Engineers (RSEs) - Impressum (legal notice)
+exclude: true
 ---
 
 # Impressum (legal notice)

--- a/de/index.md
+++ b/de/index.md
@@ -1,6 +1,7 @@
 ---
 layout: default
 title: Research Software Engineers (RSEs) - verantwortlich für wissenschaftliche Software
+exclude: true
 ---        
 
 # Research Software Engineers (RSEs) - verantwortlich für wissenschaftliche Software

--- a/de/positions-process.md
+++ b/de/positions-process.md
@@ -1,0 +1,30 @@
+---
+layout: default
+title: Positionen - Entwicklungsprozess
+exclude: true
+
+---
+
+# Entwicklungsprozess
+
+Der Entwicklungsprozess für die [Positionen der Gesellschaft](./positions.html) wurde durch die Mitglieder gestaltet und kann bei Bedarf durch die Mitglieder verändert werden. Er verläuft in drei Phasen, die wie folgt gestaltet sind.
+
+### 1. Aufruf- und Arbeitsphase
+
+1. **Call for Collaboration:** Initiatorinnen und Initiatoren einer Position kündigen das Thema auf der Mailingliste der Gesellschaft (liste@de-rse.org, mit Thema `[Call for Contribution]`) an und rufen die Mitglieder zur Mitarbeit auf. Dabei werden Hauptautorinnen und -autoren des Positionstextes benannt und die Bedingungen für Mitautorschaft erläutert.
+2. **Zusammenarbeit:** Zusammenarbeit beginnt auf einer bevorzugt öffentlichen Plattform nach Wahl der Initiatorinnen und Initiatoren (\*Pad, Repository, hackmd.io, Overleaf, o.ä.). Das Projekt wird gleichzeitig vorgestellt und verlinkt auf der de-rse.org Website unter ["Positionen" > "Work in progress"](https://www.de-rse.org/de/positions.html#work-in-progress).
+
+### 2. Begutachtungsphase
+
+1. **Veröffentlichung:** Nach Fertigstellung eines zur Veröffentlichung vorgeschlagenen Entwurfs wird dieser zur Begutachtung freigegeben:
+    - Soll die Position auf der de-RSE-Website unter "Positionen" veröffentlicht werden, wird ein entsprechender Pull Request (PR) gegen <https://github.com/DE-RSE/www> gestellt.
+    - Ist eine andere Veröffentlichungsform vorgesehen, wird ein entsprechendes Issue auf <https://github.com/DE-RSE/projekte> eröffnet, das einen Link zum Entwurf enthält.
+2. **Call for Reviews:** Die Entwurfsveröffentlichung wird wiederum über die Mailingliste (liste@de-rse.org, mit Thema `[Call for Reviews]`) bekanntgegeben, mit Link zum Pull Request/Issue. Die Mitgliedschaft wird zur Begutachtung bis zu einem geeigneten Termin aufgerufen.
+3. **Begutachtung:** Die Mitgliedschaft begutachtet öffentlich den Entwurf im PR/Issue. Sollte der Entwurf eine kontroverse Diskussion initiieren, ist der PR/Issue mit einem Label `[Kontroverse]` zu markieren. Kontroverse Diskussionen/Gutachten sind solche, die in einem Peer-Review-Verfahren zu einer ablehnenden Entscheidung oder eine "Major revision" führen würden.
+
+### 3. Entscheidungsphase
+
+1. **Entscheidung:** Der Vorstand entscheidet, ob die vertretenen Positionen als "offizielle" Position von de-RSE e.V. - Gesellschaft für Forschungssoftware eingestuft werden:
+    - Bei Diskussionen, die nicht als kontrovers gekennzeichnet wurden, wird die Entscheidung von mindestens einem Vorstandsmitglied getroffen.
+    - Bei kontroversen Diskussionen/Gutachten entscheidet der Vorstand in einer Vorstandssitzung nach Möglichkeit im Konsens. Kann eine Einigung nicht gefunden werden, entscheidet der Vorstand mit einfacher Mehrheit.
+2. **Umsetzung:** Eine Freigabe zur Veröffentlichung als Position des de-RSE e.V. wird umgesetzt entweder als Mergen und Schließen des entsprechenden Pull Request und Veröffentlichung der Position auf der Website, oder als Imprimatur-Kommentar ("Freigabe") und Schließen des entsprechenden Issue. Erfolgt keine Freigabe, kann der Vorstand den Entwurf zur Überarbeitung zurück an die Autorenschaft geben, dies wird im entsprechenden Issue/PR per Kommentar vermerkt. Hierbei sind Hinweise zu benötigten Änderungen zu geben. Alternativ kann der Vorstand den Entwurf ablehnen. Hierbei werden Issue/PR mit entsprechendem Kommentar geschlossen und es erfolgt keine Veröffentlichung.

--- a/de/positions-process.md
+++ b/de/positions-process.md
@@ -7,7 +7,7 @@ exclude: true
 
 # Entwicklungsprozess
 
-Der Entwicklungsprozess für die [Positionen der Gesellschaft](./positions.html) wurde durch die Mitglieder gestaltet und kann bei Bedarf durch die Mitglieder verändert werden. Er verläuft in drei Phasen, die wie folgt gestaltet sind.
+Der Entwicklungsprozess für die [Positionen der Gesellschaft](./positions.html) wurde durch die Mitglieder erarbeitet. Er verläuft in drei Phasen, die wie folgt gestaltet sind. Der Prozess kann bei Bedarf durch die Mitglieder verändert werden, wobei das Vorgehen hierbei dasselbe wie bei der Erarbeitung einer Position ist.
 
 ### 1. Aufruf- und Arbeitsphase
 

--- a/de/positions.md
+++ b/de/positions.md
@@ -8,44 +8,12 @@ weight: 15
 
 Als *de-RSE e.V. - Gesellschaft für Forschungssoftware* entwickeln und beziehen wir Positionen zu verschiedenen Aspekten rund um Forschungssoftware und zu Themen, die involvierte Personen, Gruppen, Strukturen und Institutionen betreffen. Hierbei nehmen wir den Standpunkt einer heterogenen Community ein, die Research Software Engineers über das gesamte Spektrum der Rollen und Selbstverständnisse umfasst und übernehmen deren Vertretung im öffentlichen Diskurs.
 
-Unsere Positionen sind das Ergebnis [öffentlicher Community-Prozesse](#entwicklungsprozess), den alle Mitglieder der Gesellschaft aktiv gestalten. Dieses Prozessmodell beinhaltet offene Calls for Contribution, kollaborative Entwicklung, öffentliche Gutachtenprozesse und darauf basierende Entscheidungen.
+Unsere Positionen sind das Ergebnis [öffentlicher Community-Prozesse](positions-process.html), den alle Mitglieder der Gesellschaft aktiv gestalten. Dieses Prozessmodell beinhaltet offene Calls for Contribution, kollaborative Entwicklung, öffentliche Gutachtenprozesse und darauf basierende Entscheidungen.
 
 Vertreten Mitglieder von de-RSE e.V. berechtigterweise die Gesellschaft in der Öffentlichkeit, vertreten sie in relevanten Diskursen auch die angenommenen Positionen.
 
-> **Inhalt**
->
-> [Work in progress](#work-in-progress) - Positionen, an denen derzeit gearbeitet wird  
-> [Entwicklungsprozess](#entwicklungsprozess) - Übersicht, wie Positionen von *de-RSE e.V.* erarbeitet werden
-
-## Work in progress
-
-Folgende Positionen sind derzeit in Arbeit.
+# Aktuelle Positionen
 
 [//]: # - [Entwicklungsprozess für Positionen von de-RSE e.V. - Gesellschaft für Forschungssoftware](https://github.com/DE-RSE/www/pull/129)
 
 (keine)
-
-
-## Entwicklungsprozess
-
-Der Entwicklungsprozess für die Positionen der Gesellschaft wurde durch die Mitglieder gestaltet und kann bei Bedarf durch die Mitglieder verändert werden. Er verläuft in drei Phasen, die wie folgt gestaltet sind.
-
-### 1. Aufruf- und Arbeitsphase
-
-1. **Call for Collaboration:** Initiatorinnen und Initiatoren einer Position kündigen das Thema auf der Mailingliste der Gesellschaft (liste@de-rse.org, mit Thema `[Call for Contribution]`) an und rufen die Mitglieder zur Mitarbeit auf. Dabei werden Hauptautorinnen und -autoren des Positionstextes benannt und die Bedingungen für Mitautorschaft erläutert.
-2. **Zusammenarbeit:** Zusammenarbeit beginnt auf einer bevorzugt öffentlichen Plattform nach Wahl der Initiatorinnen und Initiatoren (\*Pad, Repository, hackmd.io, Overleaf, o.ä.). Das Projekt wird gleichzeitig vorgestellt und verlinkt auf der de-rse.org Website unter ["Positionen" > "Work in progress"](https://www.de-rse.org/de/positions.html#work-in-progress).
-
-### 2. Begutachtungsphase
-
-1. **Veröffentlichung:** Nach Fertigstellung eines zur Veröffentlichung vorgeschlagenen Entwurfs wird dieser zur Begutachtung freigegeben:
-    - Soll die Position auf der de-RSE-Website unter "Positionen" veröffentlicht werden, wird ein entsprechender Pull Request (PR) gegen <https://github.com/DE-RSE/www> gestellt.
-    - Ist eine andere Veröffentlichungsform vorgesehen, wird ein entsprechendes Issue auf <https://github.com/DE-RSE/projekte> eröffnet, das einen Link zum Entwurf enthält.
-2. **Call for Reviews:** Die Entwurfsveröffentlichung wird wiederum über die Mailingliste (liste@de-rse.org, mit Thema `[Call for Reviews]`) bekanntgegeben, mit Link zum Pull Request/Issue. Die Mitgliedschaft wird zur Begutachtung bis zu einem geeigneten Termin aufgerufen.
-3. **Begutachtung:** Die Mitgliedschaft begutachtet öffentlich den Entwurf im PR/Issue. Sollte der Entwurf eine kontroverse Diskussion initiieren, ist der PR/Issue mit einem Label `[Kontroverse]` zu markieren. Kontroverse Diskussionen/Gutachten sind solche, die in einem Peer-Review-Verfahren zu einer ablehnenden Entscheidung oder eine "Major revision" führen würden.
-
-### 3. Entscheidungsphase
-
-1. **Entscheidung:** Der Vorstand entscheidet, ob die vertretenen Positionen als "offizielle" Position von de-RSE e.V. - Gesellschaft für Forschungssoftware eingestuft werden:
-    - Bei Diskussionen, die nicht als kontrovers gekennzeichnet wurden, wird die Entscheidung von mindestens einem Vorstandsmitglied getroffen.
-    - Bei kontroversen Diskussionen/Gutachten entscheidet der Vorstand in einer Vorstandssitzung nach Möglichkeit im Konsens. Kann eine Einigung nicht gefunden werden, entscheidet der Vorstand mit einfacher Mehrheit.
-2. **Umsetzung:** Eine Freigabe zur Veröffentlichung als Position des de-RSE e.V. wird umgesetzt entweder als Mergen und Schließen des entsprechenden Pull Request und Veröffentlichung der Position auf der Website, oder als Imprimatur-Kommentar ("Freigabe") und Schließen des entsprechenden Issue. Erfolgt keine Freigabe, kann der Vorstand den Entwurf zur Überarbeitung zurück an die Autorenschaft geben, dies wird im entsprechenden Issue/PR per Kommentar vermerkt. Hierbei sind Hinweise zu benötigten Änderungen zu geben. Alternativ kann der Vorstand den Entwurf ablehnen. Hierbei werden Issue/PR mit entsprechendem Kommentar geschlossen und es erfolgt keine Veröffentlichung.

--- a/en/imprint.md
+++ b/en/imprint.md
@@ -1,6 +1,7 @@
 ---
 layout: default
 title: Research Software Engineers (RSEs) - Impressum (legal notice)
+exclude: true
 ---
 
 # Impressum (legal notice)

--- a/en/index.md
+++ b/en/index.md
@@ -1,6 +1,7 @@
 ---
 layout: default
 title: Research Software Engineers (RSEs) - The people behind research software
+exclude: true
 ---
 
 # Research Software Engineers (RSEs) - The people behind research software

--- a/en/positions-process.md
+++ b/en/positions-process.md
@@ -1,0 +1,29 @@
+---
+layout: default
+title: Positions - Development process
+exclude: true
+---
+
+## Development process
+
+The development process for [positions of the Society](./positions.html) has been developed by its members and can be changed by its members if the need arises. It has three phases, which are set up as follows.
+
+### 1. Call and work phase
+
+1. **Call for Collaboration:** Initiators of a position announce the topic on the Society's mailing list (list@de-rse.org, with subject `[Call for contributions]`), and invite all members to collaborate. The call names main authors of the position text, and explains the prerequisites for authorship.
+2. **Collaboration:** Collaboration starts on a - preferably public - platform of the initiators' choice (\*Pad, repository, hackmd.io, Overleaf, etc.). At the same time, the project is presented and linked to on the de-rse.org website under ["Positions" > "Work in progress"](https://www.de-rse.org/en/positions.html#work-in-progress).
+
+### 2. Review phase
+
+1. **Publication:** Once a draft is deemed ready for publication, it is published for review:
+    - If the position is to be published on the de-RSE website under "Positions", a respective pull request (PR) is created against <https://github.com/DE-RSE/www>.
+    - If the position is to be published in another format, a respective issue is created on <https://github.com/DE-RSE/projekte>, which contains a link to the draft.
+2. **Call for reviews:** The draft publication is announced on the mailing list (liste@de-rse.org, with subject `[Call for Reviews]`), and the link to the respective issue/PR is provided. All members are invited to review the draft until a suitable date.
+3. **Reviews:** Members review the draft publicly in the PR/issue. Should the draft initiate a controversial discussion, the PR/issue is marked with the label `[Kontroverse]`. Controversial discussions/reviews are those which, in a peer review process, would lead to a rejection or "major revision" decision.
+
+### 3. Decision phase
+
+1. **Decision:** The board decides if the developed position is to be classified as an "official" position of de-RSE e.V. - Society for Research Software:
+    - When review discussions are not labeled as controversial, decisions on a position are made by at least one member of the board.
+    - When review discussions are labeled as controversial, the board aims to make a decision by consensus. If no consensual agreement can be arrived at, the board makes a decision based on a simple majority vote.
+2. **Implementation:** An approval for publication as a position of de-RSE e.V. is implemented either by merging and closing the respective issue or pull request and publication of the position on the website, or through an approval comment in and subsequent closing of the respective issue or pull request. If a position draft is not approved, the board can either return the draft to the authors for revision, and note this in the respective issue/PR together with indication of necessary changes, or reject the draft, and close the respective issue/PR with a suitable comment, in which case the position will not be published.

--- a/en/positions-process.md
+++ b/en/positions-process.md
@@ -6,7 +6,8 @@ exclude: true
 
 ## Development process
 
-The development process for [positions of the Society](./positions.html) has been developed by its members and can be changed by its members if the need arises. It has three phases, which are set up as follows.
+The development process for [positions of the Society](./positions.html) has been developed by its members. It has three phases, which are set up as follows.
+The process can be changed by its members, following the same procedure as the development of positions.
 
 ### 1. Call and work phase
 

--- a/en/positions.md
+++ b/en/positions.md
@@ -8,7 +8,7 @@ weight: 15
 
 As *de-RSE e.V. - Society for Research Software*, we develop and take positions on different aspects of research software, and on topics that affect the people, groups, structures and institutions involved in research software. In doing so, we take the viewpoint of a heterogeneous community, which includes Research Software Engineers across the spectrum of roles and concepts, and represent them in the public discourse.
 
-Our positions are developed in [open community processes](#development-process), which are actively shaped by our members. This process model includes open calls for collaboration, collaborative development, and open review processes upon which decisions are based.
+Our positions are developed in [open community processes](./positions-process.html), which are actively shaped by our members. This process model includes open calls for collaboration, collaborative development, and open review processes upon which decisions are based.
 
 When members of de-RSE e.V. represent the Society in public, they take the accepted positions in relevant discourse.
 

--- a/en/positions.md
+++ b/en/positions.md
@@ -12,40 +12,8 @@ Our positions are developed in [open community processes](#development-process),
 
 When members of de-RSE e.V. represent the Society in public, they take the accepted positions in relevant discourse.
 
-> **Table of contents**
->
-> [Work in progress](#work-in-progress) - Positions which are currently under development  
-> [Development process](#development-process) - An overview of how positions are developed within *de-RSE e.V.*
-
-## Work in progress
-
-The following positions are currently developed.
-
+## Current positions
 
 [//]: # - [Development process for positions of the Society](https://github.com/DE-RSE/www/pull/129)
 
 (none)
-
-## Development process
-
-The development process for positions of the Society has been developed by its members and can be changed by its members if the need arises. It has three phases, which are set up as follows.
-
-### 1. Call and work phase
-
-1. **Call for Collaboration:** Initiators of a position announce the topic on the Society's mailing list (list@de-rse.org, with subject `[Call for contributions]`), and invite all members to collaborate. The call names main authors of the position text, and explains the prerequisites for authorship.
-2. **Collaboration:** Collaboration starts on a - preferably public - platform of the initiators' choice (\*Pad, repository, hackmd.io, Overleaf, etc.). At the same time, the project is presented and linked to on the de-rse.org website under ["Positions" > "Work in progress"](https://www.de-rse.org/en/positions.html#work-in-progress).
-
-### 2. Review phase
-
-1. **Publication:** Once a draft is deemed ready for publication, it is published for review:
-    - If the position is to be published on the de-RSE website under "Positions", a respective pull request (PR) is created against <https://github.com/DE-RSE/www>.
-    - If the position is to be published in another format, a respective issue is created on <https://github.com/DE-RSE/projekte>, which contains a link to the draft.
-2. **Call for reviews:** The draft publication is announced on the mailing list (liste@de-rse.org, with subject `[Call for Reviews]`), and the link to the respective issue/PR is provided. All members are invited to review the draft until a suitable date.
-3. **Reviews:** Members review the draft publicly in the PR/issue. Should the draft initiate a controversial discussion, the PR/issue is marked with the label `[Kontroverse]`. Controversial discussions/reviews are those which, in a peer review process, would lead to a rejection or "major revision" decision.
-
-### 3. Decision phase
-
-1. **Decision:** The board decides if the developed position is to be classified as an "official" position of de-RSE e.V. - Society for Research Software:
-    - When review discussions are not labeled as controversial, decisions on a position are made by at least one member of the board.
-    - When review discussions are labeled as controversial, the board aims to make a decision by consensus. If no consensual agreement can be arrived at, the board makes a decision based on a simple majority vote.
-2. **Implementation:** An approval for publication as a position of de-RSE e.V. is implemented either by merging and closing the respective issue or pull request and publication of the position on the website, or through an approval comment in and subsequent closing of the respective issue or pull request. If a position draft is not approved, the board can either return the draft to the authors for revision, and note this in the respective issue/PR together with indication of necessary changes, or reject the draft, and close the respective issue/PR with a suitable comment, in which case the position will not be published.


### PR DESCRIPTION
As discussed on the board, this PR prepares a split of the positions page into a list of positions and a description of the development process. The list page is the target of the navigation link, and both pages link each other.

Requirements for merge:

- [ ] At least one actual position is published so that the list is no longer empty (This can be a work in progress link to a PR draft)

Note to reviewers: Should the link to the respective other page be more visible, e.g., under its own header?