### PR TITLE
Set up deRSE20

### DIFF
--- a/_posts/2019-11-01-derse20-call-for-committee-members.md
+++ b/_posts/2019-11-01-derse20-call-for-committee-members.md
@@ -1,0 +1,69 @@
+---
+title: "deRSE20 Call for Committee Members"
+layout: post
+author: Stephan Druskat & de-RSE e.V. Vorstand
+menulang: de
+---
+
+<!-- # deRSE20 Call for Committee Members -->
+
+Du möchtest *aktiv* die Zukunft der Community der Research Software Engineers (RSEs) in Deutschland mitbestimmen?
+Mach mit beim Organisationskomitee für die zweite internationale Konferenz der Research Software Engineers in Deutschland (*deRSE20*)!
+
+## deRSE20
+
+Die [erste internationale Konferenz der Research Software Engineers in Deutschland - deRSE19](https://www.de-rse.org/de/conf2019/) - fand vom 4. bis 6. Juni 2019 in Potsdam statt und war ein großer Erfolg! Mehr als 200 Teilnehmende aus 7 Ländern diskutierten Forschungssoftware in allen Aspekten und bauten gemeinsam an einer Community.
+
+Organisiert wurde die deRSE19 von der Community für die Community der Research Software Engineers in Deutschland, konkret von einem Team aus mehr als 30 Freiwilligen, die die Konferenz als Mitglieder des Organisations- oder Programmkomitees oder als Helfer_innen vor Ort planten und durchführten.
+
+2020 wollen wir die Konferenz fortführen, um die Community wieder zusammenzubringen und auszubauen.
+
+Die Konferenz wird aller Voraussicht nach an **3 Tagen im Zeitraum 17.08.-27.08.2020 in Jena** stattfinden.
+<!-- Wenn Du auf dem Laufenden bleiben willst, abonniere die Mailingliste [konferenz-updates@de-rse.org](https://ml-cgn04.ispgateway.de/mailman/listinfo/konferenz-updates_de-rse.org). -->
+
+Um die Konferenz planen und durchführen zu können, suchen wir Chairs und Komiteemitglieder, die am Gelingen der Konferenz mitarbeiten wollen.
+
+## Wie werde ich Teil des Organisationsteams?
+
+Bitte schreibe eine E-Mail mit Betreff "*deRSE20 Interesse an Mitarbeit*" an vorstand@de-rse.org. Bitte nenne dabei Deine Heimatinstitution und die Rolle, die Du gern bei der Konferenzorganisation übernehmen möchtest (s.u.).
+
+Am *Montag, 4.11.2019*, findet um 11:00 Uhr eine **Kickoff-Webkonferenz** zur deRSE20 statt. Hier kannst Du unverbindlich reinschnuppern, andere Interessierte kennenlernen und Fragen stellen.
+
+> _**deRSE20 Kickoff-Webkonferenz**_  
+> **Montag, 04.11.2019, 11:00 Uhr**  
+> <https://conf.dfn.de/webapp/conference/97957793>, oder  
+> [+49-30-200-97957793](tel:+49-30-200-97957793)
+
+## Vorteile für Mitglieder des Organisationsteams
+
+Das Organisationsteam gestaltet die RSE-Community in Deutschland aktiv mit und leistet einen entscheidenden Beitrag zur Wirkungskraft dieser Community! Mitglieder lernen in ihrer Arbeit im Komitee neue Personen, Initiativen und Ideen aus dem Bereich Forschungssoftware kennen, sowie die Höhen und Tiefen der Konferenzorganisation. Es ist weiterhin geplant, dass Komiteemitglieder freien Eintritt zur Konferenz erhalten.
+
+## Was bedeutet es, ein Mitglied des Organisationsteams zu sein?
+
+- Teammitglieder unterstützen die inhaltliche Ausrichtung von de-RSE e.V. und deRSE20-Konferenz.
+- Sie sind sich im Klaren, dass die Organisation der Konferenz Zeit, Kraft und Nerven kostet. Je nach Team trifft das mehr oder weniger zu und kann zu unterschiedlichen Zeiten eintreffen.
+- Sie sind gewillt und in der Lage, persönlich an der Konferenz teilzunehmen, wobei dafür finanzielle Unterstützung geplant ist.
+- Sie sind in der Lage, die von ihnen übernommenen Aufgaben zu erledigen, oder gewillt, benötigte Fähigkeiten kurzfristig zu erlernen.
+- Von Teammitgliedern wird erwartet, dass sie sich an den [Code of Conduct (CoC) der deRSE19](https://www.de-rse.org/de/conf2019/code-of-conduct.html) halten. Nach eventueller Ablösung dieses Code of Conduct halten sie sich an den jeweils gültigen CoC.
+- Teammitglieder zeigen keine Voreingenommenheit gegenüber Einzelnen oder einer Teilgruppe des gesamten Konferenzkomitees, der Teilnehmerschaft der Konferenz, oder anderer Beteiligter (Veranstaltungsort, Sponsoren, etc.)
+
+
+## Konferenzteams
+
+Wir suchen Mitglieder für folgende Teams:
+
+- **Programm-Team:** Ein Chair + Komitee organisieren das Programm der Konferenz, planen Formate und Tracks, entwerfen einen Call for Submissions, organisieren den Einreichungs- und Begutachtungsprozess, führen letzteren mit durch, treffen und kommunizieren Entscheidungen mit einreichenden Personen, gestalten und kommunizieren den Programmablauf und organisieren Session Chairs für die einzelnen Veranstaltungsblöcke während der Konferenz (letzteres in Zusammenarbeit mit dem Volunteers-Team).
+    - Je nach geplanten Formaten: **Teams für jedes Format:** Ein Chair + Team führen die Aufgaben des Programmkomitees jeweils für ein Format durch, z.B. für Vorträge, Poster, Workshops und BoFs, etc. Diese Teams bilden zusammen mit dem Programm-Chair das Programmkomitee.
+- **Logistik-Team (a.k.a. Local Team):** Ein Chair + Team  sind *vor Ort in Jena oder Umgebung* ansässig und unterstützen den Logistik Chair bei der Organisation des Veranstaltungsortes. Dies umfasst v.a. zum einen die Organisation von Räumen, räumlichen und zeitlichen Abläufen, benötigter Technik und Ausstattung, zum anderen die Kommunikation und Organisation vor Ort mit Zulieferern (Catering, Transport, etc.) und die Bereitstellung der entsprechenden Informationen für die anderen Teams und die Teilnehmer.
+- **Finanz-Team:** Ein oder zwei Chairs + Team planen, verwalten, überwachen und berichten die Finanzen der Konferenz, kümmern sich um eingehende und zu leistende Zahlungen, legen Rechnungen, etc.
+- **Website-Team:** Ein Chair + Team kümmern sich um die Pflege der Websites. Dies umfasst zum einen die statische Konferenz-Website, zum anderen die Webtools für die Konferenzorganisation (Einreichungssystem, Ticketingsystem, Publikationssystem für Beiträge, etc.).
+- **Sponsorship-Team:** Ein Chair + Team kümmern sich um die Gewinnung von Sponsoren für die Konferenz, sprechen Sponsorship-Leistungen mit diesen ab, klären die Ausführung der Leistungen mit Logistik-Team, Financial-Team u.a. und sind Liaison - auch vor Ort während der Konferenz - zwischen Sponsoren und Konferenzkomitee insgesamt.
+- **Volunteers-Team:** Ein Chair + Team kümmern sich um die Gewinnung und Organisation von freiwilligen Helfer_innen für die Konferenz und organisieren vor allem Abläufe und Einsatz dieser während der Konferenz. Das Team arbeitet eng mit dem Logistik-Team zusammen. Bestenfalls ist mindestens der Chair in *Jena oder Umgebung* ansässig und kennt die Veranstaltungsorte gut oder lernt sie frühzeitig kennen.
+- **Diversity-Team:** Ein Chair + Team kümmern sich um die Aspekte der Diversität der Konferenz, entwerfen entsprechende Policies und deren Umsetzung (z.B. Code of Conduct), schlagen Mechanismen zur Diversitätssteigerung der Konferenz vor, überwachen und kommunizieren Aspekte der Diversität über alle Teams hinweg, dokumentieren die Diversität der Konferenz und kommunizieren entsprechende Trends.
+- **International-Team:** Ein Chair + Team kümmern sich um die Anbindung der Konferenz an internationale Initiativen, erstellen und kommunizieren Konzepte der Einbindung internationaler Teilnehmender, klären Fördermöglichkeiten für internationale Teilnehmende, kommunizieren mit der internationalen Community und berichten von der Konferenz auf internationale Plattformen (Blogs, Konferenzen, etc.).
+- **Social-Team:** Ein Chair + Team organisiert das soziale Rahmenprogramm der Konferenz in allen Aspekten, also z.B. Pre-Conference Dinner/Meeting/Reception, Führungen, sportliche Aktivitäten (Laufgruppe), Networking-Aktivitäten (z.B. Sitzplan für das Konferenzdinner o.ä.).
+- **Social Media-Team:** Ein Chair + Team kümmern sich um die Pflege der Social Media Accounts (v.a. Twitter/Mastodon) der Konferenz. Das Team veröffentlicht News und Updates zur Konferenz - vor, während und nach der Veranstaltung - und trifft vor allem eine Auswahl, was während der Konferenz live veröffentlicht oder geteilt wird. Das Team gestaltet das öffentliche Gesicht der Konferenz in den sozialen Medien.
+
+### Chairs und Teams
+
+Die anstehenden Aufgaben sollen auf viele Schultern verteilt werden. Dazu arbeiten wir in Teams, die sich auf bestimmte Themen fokussieren und von Chairs zusammengehalten werden. Die Teammitglieder organisieren sich dabei selbständig, teilen sich Aufgaben untereinander auf und gehen diese gemeinsam an. Damit die einzelnen Aktivitäten abgestimmt und zielgerichtet eine erfolgreiche Konferenz ermöglichen, übernehmen 1-2 Personen aus einem Team die Rolle eines Chairs. Chairs übernehmen die Kommunikation für ihr Team im Konferenzkommittee in regelmäßig stattfindenden Videokonferenzen, stimmen die Organisation des eigenen Teams mit den anderen Teams ab und kümmern sich um das Tracking von Prozessen innerhalb des Teams, um darüber zu berichten.

--- a/de/events.md
+++ b/de/events.md
@@ -12,6 +12,16 @@ sind auf den verwiesenen Webseiten zu finden.
 
 Falls eine Veranstaltung fehlt, [kontaktiere](join.html) uns bitte.
 
+## deRSE-Konferenzen
+
+Die **deRSE**-Konferenzen sind von uns veranstaltete, internationale Konferenzen von und für Research Software Engineers.
+
+### deRSE19
+
+Die 1. Konferenz für ForschungssoftwareentwicklerInnen in Deutschland fand vom 4.6. - 6.6. 2019 in Potsdam statt.
+
+#### \> [Konferenzwebsite für deRSE19](conf2019/)
+
 ## 2019  
 
 | Veranstaltung | Datum | Ort | URL | Bemerkung |

--- a/en/events.md
+++ b/en/events.md
@@ -10,6 +10,16 @@ We think this list of events is relevant. That's why simply collected them in a 
 
 If you think, we are missing an event, please [contact](join.html) us.
 
+## deRSE conferences
+
+We organize the international **deRSE** conferences, by and for Research Software Engineers.
+
+### deRSE19
+
+The 1st conference of Research Software Engineers in Germany took place from 4 - 6 June 2019 in Potsdam.
+
+#### \> [Conference website for deRSE19](conf2019/)
+
 ## 2019  
 
 | Event | Date | Place | URL | Remarks |


### PR DESCRIPTION
This PR

- adds links to the deRSE19 subsite to the events page, in preparation of setting up the navbar for deRSE20
- Publishes the call for committee members as a blog post. As the konferenz-updates@de-rse.org mailing list registration page currently doesn't work (@knarrff can you please add the correct link?), and the navbar needs to be fixed before adding the deRSE20 link (see #136), this is currently the best option, as we'll have the kickoff webconf next Monday already.