### PR TITLE
Add event list for 2020

### DIFF
--- a/_includes/events/2020.md
+++ b/_includes/events/2020.md
@@ -1,0 +1,8 @@
+| FOSDEM 2020 | 1.-2.2.2020 | Brussels | [fosdem.org/2020](https://fosdem.org/2020/) | Free! |
+| RDA Deutschland Tagung 2020 | 25.-27.2.2020 | Potsdam | [rda-deutschland.de/events/tagung-2020](https://www.rda-deutschland.de/events/tagung-2020) | |
+| MPG Open Science Days | 2.-3.3.2020 | Berlin | [osd.mpdl.mpg.de](https://osd.mpdl.mpg.de) | |
+| Open Science Barcamp | 10.3.2020 | Berlin | [www.open-science-conference.eu/barcamp](https://www.open-science-conference.eu/barcamp/) | Free! |
+| Chemnitzer Linux Tage | 14.-15.3.2020 | Chemnitz | [chemnitzer.linux-tage.de/2020](https://chemnitzer.linux-tage.de/2020/) | |
+| Collaborations Workshop 2020 | 31.3.-2.4.2020 | Belfast | [www.software.ac.uk/cw20](https://www.software.ac.uk/cw20) | |
+| FrOSCon | 22.-23.8.2020 | Sankt Augustin | [froscon.de](https://www.froscon.de/) | |
+| deRSE20 | Aug 2020 | Jena | coming soon | |

--- a/de/events.md
+++ b/de/events.md
@@ -22,6 +22,13 @@ Die 1. Konferenz für ForschungssoftwareentwicklerInnen in Deutschland fand vom 
 
 #### \> [Konferenzwebsite für deRSE19](conf2019/)
 
+## 2020  
+
+| Veranstaltung | Datum | Ort | URL | Bemerkung |
+| --- | --- | --- | --- | --- |
+{% include events/2020.md %}
+{: .table .table-hover}
+
 ## 2019  
 
 | Veranstaltung | Datum | Ort | URL | Bemerkung |

--- a/en/events.md
+++ b/en/events.md
@@ -20,6 +20,13 @@ The 1st conference of Research Software Engineers in Germany took place from 4 -
 
 #### \> [Conference website for deRSE19](conf2019/)
 
+## 2020  
+
+| Event | Date | Place | URL | Remarks |
+| --- | --- | --- | --- | --- |
+{% include events/2020.md %}
+{: .table .table-hover}
+
 ## 2019  
 
 | Event | Date | Place | URL | Remarks |


### PR DESCRIPTION
Currently there is no list for events and conferences in 2020.
Add event list and include it in the respective pages.
Populate event list with dates for Q1/2020 (and some beyond).